### PR TITLE
Add report form and button to individual posts only

### DIFF
--- a/meetup-wordpress-medellin.php
+++ b/meetup-wordpress-medellin.php
@@ -7,7 +7,7 @@
  */
 
 /**
- * Función principal utilizada para hacer las verficaciones iniciales y
+ * Función principal utilizada para hacer las verificaciones iniciales y
  * configurar las acciones y filtros que soportan la funcionalidad del
  * plugin.
  *

--- a/meetup-wordpress-medellin.php
+++ b/meetup-wordpress-medellin.php
@@ -17,7 +17,6 @@ function mwpm_wordpress_configured() {
     // El formulario para reportar entradas solo será mostrado en páginas y
     // publicaciones individuales.
     if ( is_single() || is_page() ) {
-        add_filter( 'the_content', 'mwpm_add_report_button_to_content' );
         add_action( 'wp_enqueue_scripts', 'mwpm_enqueue_style' );
         add_action( 'wp_footer', 'mwpm_enqueue_script' );
     }
@@ -36,15 +35,22 @@ function mwpm_generate_button_for_post( $post_id ) {
 } 
 
 function mwpm_add_report_button_to_content( $content ) {
-    $report_button  = '';
-    $report_button .= '<p>';
-    $report_button .= mwpm_generate_button_for_post( get_the_ID() );
-    $report_button .= '</p>';
+    // El formulario para reportar entradas solo será mostrado en páginas y
+    // publicaciones individuales.
+    if ( is_single() || is_page() ) {
+        $report_button  = '';
+        $report_button .= '<p>';
+        $report_button .= mwpm_generate_button_for_post( get_the_ID() );
+        $report_button .= '</p>';
 
-    $report_modal = mwpm_render_report_modal();
+        $report_modal = mwpm_render_report_modal();
 
-    return $report_button . $content . $report_modal;
+        return $report_button . $content . $report_modal;
+    }
+
+    return $content;
 }
+add_filter( 'the_content', 'mwpm_add_report_button_to_content' );
 
 function mwpm_maybe_send_report() {
     // Validar que existan los datos del reporte.

--- a/meetup-wordpress-medellin.php
+++ b/meetup-wordpress-medellin.php
@@ -6,6 +6,24 @@
  * Version: 1.0.0
  */
 
+/**
+ * Función principal utilizada para hacer las verficaciones iniciales y
+ * configurar las acciones y filtros que soportan la funcionalidad del
+ * plugin.
+ *
+ * @since 1.0.0
+ */
+function mwpm_wordpress_configured() {
+    // El formulario para reportar entradas solo será mostrado en páginas y
+    // publicaciones individuales.
+    if ( is_single() || is_page() ) {
+        add_filter( 'the_content', 'mwpm_add_report_button_to_content' );
+        add_action( 'wp_enqueue_scripts', 'mwpm_enqueue_style' );
+        add_action( 'wp_footer', 'mwpm_enqueue_script' );
+    }
+}
+add_action( 'wp', 'mwpm_wordpress_configured' );
+
 function mwpm_generate_button_for_post( $post_id ) {
     $user_id = get_current_user_id();
     $button  = '';
@@ -22,9 +40,11 @@ function mwpm_add_report_button_to_content( $content ) {
     $like_box .= '<p>';
     $like_box .= mwpm_generate_button_for_post( get_the_ID() );
     $like_box .= '</p>';
-    return $like_box . $content;
+
+    $report_modal = mwpm_render_report_modal();
+
+    return $like_box . $content . $report_modal;
 }
-add_filter( 'the_content', 'mwpm_add_report_button_to_content' );
 
 function mwpm_maybe_send_report() {
     // Validar que existan los datos del reporte.
@@ -68,7 +88,13 @@ function mwpm_maybe_send_report() {
 }
 add_action( 'wp', 'mwpm_maybe_send_report' );
 
-function mwpm_add_modal_to_footer() {
+/**
+ * Crea el código HTML para el formulario que los usuarios podrán utilizar
+ * para reportar una entrada.
+ *
+ * @since 1.0.0
+ */
+function mwpm_render_report_modal() {
     $modal = '
     <!-- Report Post Modal -->
     <div id="reportModal" class="report-modal">
@@ -99,10 +125,8 @@ function mwpm_add_modal_to_footer() {
         </div>
     </div>';
 
-    echo $modal;
+    return $modal;
 }
-add_action( 'wp_footer', 'mwpm_add_modal_to_footer' );
-
 
 function mwpm_enqueue_style() {
     wp_enqueue_style(
@@ -111,7 +135,6 @@ function mwpm_enqueue_style() {
         false
     ); 
 }
-add_action( 'wp_enqueue_scripts', 'mwpm_enqueue_style' );
 
 function mwpm_enqueue_script() {
     wp_enqueue_script(
@@ -120,7 +143,6 @@ function mwpm_enqueue_script() {
         false
     );
 }
-add_action( 'wp_footer', 'mwpm_enqueue_script' );
 
 function mwpm_get_headers( $report ) {
     $headers = array();

--- a/meetup-wordpress-medellin.php
+++ b/meetup-wordpress-medellin.php
@@ -6,23 +6,6 @@
  * Version: 1.0.0
  */
 
-/**
- * Función principal utilizada para hacer las verificaciones iniciales y
- * configurar las acciones y filtros que soportan la funcionalidad del
- * plugin.
- *
- * @since 1.0.0
- */
-function mwpm_wordpress_configured() {
-    // El formulario para reportar entradas solo será mostrado en páginas y
-    // publicaciones individuales.
-    if ( is_single() || is_page() ) {
-        add_action( 'wp_enqueue_scripts', 'mwpm_enqueue_style' );
-        add_action( 'wp_footer', 'mwpm_enqueue_script' );
-    }
-}
-add_action( 'wp', 'mwpm_wordpress_configured' );
-
 function mwpm_generate_button_for_post( $post_id ) {
     $user_id = get_current_user_id();
     $button  = '';
@@ -135,19 +118,30 @@ function mwpm_render_report_modal() {
     return $modal;
 }
 
-function mwpm_enqueue_style() {
-    wp_enqueue_style(
-        'mwpm-styles',
-        plugins_url( '/', __FILE__ ) . 'style.css'
-    ); 
-}
+/**
+ * Función asociada a la acción wp_enqueue_scripts para registrar las hojas
+ * de estilo y los scripts que el plugin necesita en el frontend.
+ *
+ * @since 1.0.0
+ */
+function mwpm_enqueue_scripts_and_styles() {
+    // Las hojas de estilo y scripts solo seran necesarios en páginas y publicaciones individuales.
+    if ( is_single() || is_page() ) {
+        wp_enqueue_style(
+            'mwpm-styles',
+            plugins_url( '/style.css', __FILE__ )
+        );
 
-function mwpm_enqueue_script() {
-    wp_enqueue_script(
-        'mwpm-script',
-        plugins_url( '/', __FILE__ ) . 'mwpm_script.js'
-    );
+        wp_enqueue_script(
+            'mwpm-script',
+            plugins_url( '/mwpm_script.js', __FILE__ ),
+            array(),
+            '1.0.0',
+            true // $in_footer = true para que el <script> se genere al final de la página.
+        );
+    }
 }
+add_action( 'wp_enqueue_scripts', 'mwpm_enqueue_scripts_and_styles' );
 
 function mwpm_get_headers( $report ) {
     $headers = array();

--- a/meetup-wordpress-medellin.php
+++ b/meetup-wordpress-medellin.php
@@ -36,14 +36,14 @@ function mwpm_generate_button_for_post( $post_id ) {
 } 
 
 function mwpm_add_report_button_to_content( $content ) {
-    $like_box  = '';
-    $like_box .= '<p>';
-    $like_box .= mwpm_generate_button_for_post( get_the_ID() );
-    $like_box .= '</p>';
+    $report_button  = '';
+    $report_button .= '<p>';
+    $report_button .= mwpm_generate_button_for_post( get_the_ID() );
+    $report_button .= '</p>';
 
     $report_modal = mwpm_render_report_modal();
 
-    return $like_box . $content . $report_modal;
+    return $report_button . $content . $report_modal;
 }
 
 function mwpm_maybe_send_report() {


### PR DESCRIPTION
Creo que para facilitar las cosas es mejor si el botón y el formulario solo aparecen en páginas individuales.

Además estoy generando el HTML del formulario durante `the_content` para garantizar que `get_the_ID()` y `get_the_title()` estén trabajando con el post que se está mostrando. Afuera del loop `$post` podría convertirse en otra cosa. No va a ocurrir en nuestro sitio de ejemplo seguramente, pero me parece mejor recomendar usar esas funciones dentro del loop  o pasando el ID de un post cuando se usen por fuera.