### PR TITLE
Función para construir el cuerpo de la notificación

### DIFF
--- a/meetup-wordpress-medellin.php
+++ b/meetup-wordpress-medellin.php
@@ -32,8 +32,9 @@ function mwpm_maybe_send_report() {
         return;
     }
 
-    // Sanitizar los datos del reporte sumisitrados por el usuario en el formulario.
-    $report  = stripslashes_deep( $_POST['report'] );
+    // Remover slashes (/) de los datos del reporte suministrados por el
+    // usuario en el formulario.
+    $report = stripslashes_deep( $_POST['report'] );
 
     // Configurar los parámetros del correo
     $to      = get_option( 'admin_email' );

--- a/meetup-wordpress-medellin.php
+++ b/meetup-wordpress-medellin.php
@@ -36,14 +36,25 @@ function mwpm_maybe_send_report() {
     // usuario en el formulario.
     $report = stripslashes_deep( $_POST['report'] );
 
-    // Configurar los parámetros del correo
+    // Configurar los parámetros del correo.
     $to      = get_option( 'admin_email' );
     $subject = sprintf (
         __( 'You have a report from your post %s', 'mwpm' ),
         get_the_title( $report['post_id'] )
     );
     $headers = mwpm_get_headers( $report );
+    $message = mwpm_build_report_email_message( $report );
 
+    // Enviar el correo con el reporte.
+    wp_mail( $to, $subject, $message, $headers );
+
+}
+add_action( 'wp', 'mwpm_maybe_send_report' );
+
+/**
+ * @since 1.0.0
+ */
+function mwpm_build_report_email_message( $report ) {
     $message  = '';
     $message .= __( 'Hi there Admin,', 'mwpm' );
     $message .= '<br/><br/>';
@@ -63,11 +74,8 @@ function mwpm_maybe_send_report() {
 
     $message .= '<a href="' . $url . '">' . $url . '</a>';
 
-    // Enviar el correo con el reporte.
-    wp_mail( $to, $subject, $message, $headers );
-
+    return $message;
 }
-add_action( 'wp', 'mwpm_maybe_send_report' );
 
 function mwpm_add_modal_to_footer() {
     $modal = '


### PR DESCRIPTION
La idea para el WordCamp era tener una lista de tareas pequeñas que los asistentes van resolviendo para construir las diferentes funciones del plugin. Para el meetup yo había imaginado algo similar: que la presentación del plugin sea una serie de slides que van mostrando el código necesario para soportar cada característica.

En ese sentido sería útil dividir todo en pequeñas funciones que hagan una sola cosa y que podamos mostrar de forma separada. Este PR agrega una función para construir el cuerpo del correo utilizando como entrada la información enviada a través del formulario.